### PR TITLE
docs: correct tech stack — code uses vanilla CSS, not Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## 🛠️ 技術棧
 
 * **HTML5**
-* **Tailwind CSS (via CDN)**：一個功能優先的 CSS 框架，用於快速建構現代化介面。
+* **Vanilla CSS3**：手寫樣式（內嵌於 `index.html` 的 `<style>` 區塊），無使用任何框架。
 * **Vanilla JavaScript (ES6+)**：無任何框架，輕量且高效。
 
 ## 🚀 如何使用


### PR DESCRIPTION
## Summary
  - README 的「技術棧」原本宣稱 `Tailwind CSS (via CDN)`，但 `index.html` 實際上是 ~770 行手寫 CSS，沒有載入任何 Tailwind 資源。
  - 更正為 `Vanilla CSS3`，避免新貢獻者被誤導去找根本不存在的 Tailwind 設定。
  - 純文件修改，不影響行為。

  ## Test plan
  - [x] `git diff` 確認只動了 README 一行
  - [ ] 在 GitHub 預覽頁面再瞄一次「技術棧」區塊渲染正常

  Labels: documentation